### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ this branch: https://github.com/datastax/cassandra/tree/cep-vsearch
   - !Note! This is a prerelease and uses `FLOAT VECTOR[N]` syntax for declaring a vector column.
     This will change in the near future.
 - JDK 11.  Exactly 11.
+- You will be able to run cqlsh with vector support if you run `bin/cqlsh` from the cassandra source root
 - Python driver with vector support from this branch: https://github.com/datastax/python-driver/tree/cep-vsearch
   - TLDR `git clone`, `python setup.py install`
-  - You will be able to run cqlsh with vector support if you additionally
-    - `pip install wcwidth` and then
-    - `CQLSH_NO_BUNDLED=True bin/cqlsh` from the cassandra source root
 - You can install the other Python dependencies for cassgpt by running 
 `pip install -r requirements.txt` from this source tree.
 


### PR DESCRIPTION
The updated python driver is in the cassandra branch now. No need to install it locally to use cqlsh.