### PR TITLE
Updates to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ This program uses OpenAI's GPT-3 to generate answers to your questions based on 
 - OpenAI API key, stored in file `openai.key`
 - Cassandra database supporting vector search. Currently that means you need to build and run 
 this branch: https://github.com/datastax/cassandra/tree/vsearch
-  - TLDR `git clone`, `git checkout vsearch`, `ant jar`, `bin/cassandra -f`
-- JDK 11.  Exactly 11.
+  - TLDR:
+    - `git clone git@github.com:datastax/cassandra.git --branch vsearch`
+    - `ant realclean`
+    - `ant jar -Duse.jdk11=true`
+    - `bin/cassandra -f`
+- JDK 11.  _Exactly_ 11.
 - You will be able to run cqlsh with vector support if you run `bin/cqlsh` from the cassandra source root
 - You can install the Python dependencies for cassgpt by running 
 `pip install -r requirements.txt` from this source tree.


### PR DESCRIPTION
- Clone directly to using `vsearch` branch
- Perform `ant realclean`
- Use JDK11